### PR TITLE
Deleted unnecessary symbols causing crash building

### DIFF
--- a/windows/include/winhooker/winhooker_plugin_c_api.h
+++ b/windows/include/winhooker/winhooker_plugin_c_api.h
@@ -9,7 +9,7 @@
 #define FLUTTER_PLUGIN_EXPORT __declspec(dllimport)
 #endif
 
-#if defined(__cplusplus)gd
+#if defined(__cplusplus)
 extern "C" {
 #endif
 


### PR DESCRIPTION
Error: 
```
..\windows\flutter\ephemeral\.plugin_symlinks\winhooker\windows\include/winhooker/winhooker_plugin_c_api.h(12,25): error C2220: ????????? ?????????????? ??????????????? ??? ?????? [...\build\windows\plugins\winhooker\winhooker_plugin.vcxproj]
..\windows\flutter\ephemeral\.plugin_symlinks\winhooker\windows\include/winhooker/winhooker_plugin_c_api.h(12,25): warning C4067: ?????????????? ??????? ?? ?????????? ?????????????, ????????? newline [...\build\windows\plugins\winhooker\winhooker_plugin.vcxproj]
Exception: Build process failed.
```